### PR TITLE
Issue 45: Plural naming of cg-ng generators are now by default.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -8,10 +8,13 @@ var CgangularGenerator = module.exports = function CgangularGenerator(args, opti
     yeoman.generators.Base.apply(this, arguments);
 
     this.on('end', function () {
-        this.config.set('partialDirectory','partial/');
-        this.config.set('directiveDirectory','directive/');
-        this.config.set('filterDirectory','filter/');
-        this.config.set('serviceDirectory','service/');
+        this.config.set('directiveDirectory' , 'directives/');
+        this.config.set('filterDirectory'    , 'filters/');
+        this.config.set('modalDirectory'     , 'modals/');
+        this.config.set('moduleDirectory'    , 'modules/');
+        this.config.set('partialDirectory'   , 'partials/');
+        this.config.set('serviceDirectory'   , 'services/');
+
         var inject = {
             js: {
                 file: 'index.html',
@@ -25,7 +28,8 @@ var CgangularGenerator = module.exports = function CgangularGenerator(args, opti
                 template: '@import "<%= filename %>";'
             }
         };
-        this.config.set('inject',inject);
+
+        this.config.set('inject', inject);
         this.config.save();
         this.installDependencies({ skipInstall: options['skip-install'] });
     });


### PR DESCRIPTION
Following up on #45, since I agree on this.
- fixed: aligned and sorted configuration
- added some space (occupational hazard)
