### PR TITLE
Fix inconsistent indentation.

### DIFF
--- a/directive/templates/complex/directive.js
+++ b/directive/templates/complex/directive.js
@@ -1,14 +1,14 @@
 angular.module('<%= appname %>').directive('<%= _.camelize(name) %>', function() {
-	return {
-		restrict: 'E',
-		replace: true,
-		scope: {
+    return {
+        restrict: 'E',
+        replace: true,
+        scope: {
 
-		},
-		templateUrl: '<%= htmlPath %>',
-		link: function(scope, element, attrs, fn) {
+        },
+        templateUrl: '<%= htmlPath %>',
+        link: function(scope, element, attrs, fn) {
 
 
-		}
-	};
+        }
+    };
 });

--- a/directive/templates/simple/directive.js
+++ b/directive/templates/simple/directive.js
@@ -1,9 +1,9 @@
 angular.module('<%= appname %>').directive('<%= _.camelize(name) %>', function() {
-	return {
-		restrict: 'A',
-		link: function(scope, element, attrs, fn) {
+    return {
+        restrict: 'A',
+        link: function(scope, element, attrs, fn) {
 
 
-		}
-	};
+        }
+    };
 });

--- a/filter/index.js
+++ b/filter/index.js
@@ -14,7 +14,7 @@ var FilterGenerator = module.exports = function FilterGenerator(args, options, c
 
     cgUtils.getNameArg(this,args);
 
-	yeoman.generators.Base.apply(this, arguments);
+    yeoman.generators.Base.apply(this, arguments);
 
 };
 

--- a/filter/templates/filter-spec.js
+++ b/filter/templates/filter-spec.js
@@ -1,13 +1,13 @@
 describe('<%= _.camelize(name) %>', function() {
 
-	beforeEach(module('<%= appname %>'));
+    beforeEach(module('<%= appname %>'));
 
-	it('should ...', inject(function($filter) {
+    it('should ...', inject(function($filter) {
 
         var filter = $filter('<%= _.camelize(name) %>');
 
-		expect(filter('input')).toEqual('output');
+        expect(filter('input')).toEqual('output');
 
-	}));
+    }));
 
 });

--- a/filter/templates/filter.js
+++ b/filter/templates/filter.js
@@ -1,5 +1,5 @@
 angular.module('<%= appname %>').filter('<%= _.camelize(name) %>', function() {
-	return function(input,arg) {
-		return 'output';
-	};
+    return function(input,arg) {
+        return 'output';
+    };
 });

--- a/modal/index.js
+++ b/modal/index.js
@@ -42,16 +42,16 @@ ModalGenerator.prototype.files = function files() {
 
     setTimeout((function(){
 
-	    console.log('');
-	    console.log('  Open this modal by using ' + chalk.bold('angular-ui-bootstrap') + ' module\'s ' + chalk.bold('$modal') + ' service:');
-	    console.log('');
-	    console.log('  $modal.open({');
-	    console.log('      templateUrl: \'' + path.join(this.dir,this.name + '.html') + '\',');
-	    console.log('      controller: \''+ this.ctrlname +'\'');
-	    console.log('  }).result.then(function(result){');
-	    console.log('      //do something with the result');
-	    console.log('  });');
-	    console.log('');
+        console.log('');
+        console.log('  Open this modal by using ' + chalk.bold('angular-ui-bootstrap') + ' module\'s ' + chalk.bold('$modal') + ' service:');
+        console.log('');
+        console.log('  $modal.open({');
+        console.log('      templateUrl: \'' + path.join(this.dir,this.name + '.html') + '\',');
+        console.log('      controller: \''+ this.ctrlname +'\'');
+        console.log('  }).result.then(function(result){');
+        console.log('      //do something with the result');
+        console.log('  });');
+        console.log('');
 
     }).bind(this),200);
 

--- a/modal/templates/modal-spec.js
+++ b/modal/templates/modal-spec.js
@@ -1,18 +1,18 @@
 describe('<%= ctrlname %>', function() {
 
-	beforeEach(module('<%= appname %>'));
+    beforeEach(module('<%= appname %>'));
 
-	var scope,ctrl;
+    var scope,ctrl;
 
     beforeEach(inject(function($rootScope, $controller) {
       scope = $rootScope.$new();
       ctrl = $controller('<%= ctrlname %>', {$scope: scope});
     }));
 
-	it('should ...', inject(function() {
+    it('should ...', inject(function() {
 
-		expect(1).toEqual(1);
+        expect(1).toEqual(1);
 
-	}));
+    }));
 
 });

--- a/partial/templates/partial-spec.js
+++ b/partial/templates/partial-spec.js
@@ -1,18 +1,18 @@
 describe('<%= ctrlname %>', function() {
 
-	beforeEach(module('<%= appname %>'));
+    beforeEach(module('<%= appname %>'));
 
-	var scope,ctrl;
+    var scope,ctrl;
 
     beforeEach(inject(function($rootScope, $controller) {
       scope = $rootScope.$new();
       ctrl = $controller('<%= ctrlname %>', {$scope: scope});
-    }));	
+    }));
 
-	it('should ...', inject(function() {
+    it('should ...', inject(function() {
 
-		expect(1).toEqual(1);
-		
-	}));
+        expect(1).toEqual(1);
+        
+    }));
 
 });

--- a/service/index.js
+++ b/service/index.js
@@ -14,7 +14,7 @@ var ServiceGenerator = module.exports = function ServiceGenerator(args, options,
 
     cgUtils.getNameArg(this,args);
 
-	yeoman.generators.Base.apply(this, arguments);
+    yeoman.generators.Base.apply(this, arguments);
 
 };
 

--- a/service/templates/service-spec.js
+++ b/service/templates/service-spec.js
@@ -4,7 +4,7 @@ describe('<%= _.camelize(name) %>', function() {
 
   it('should ...', inject(function(<%= _.camelize(name) %>) {
 
-	//expect(<%= _.camelize(name) %>.doSomething()).toEqual('something');
+    //expect(<%= _.camelize(name) %>.doSomething()).toEqual('something');
 
   }));
 

--- a/service/templates/service.js
+++ b/service/templates/service.js
@@ -1,6 +1,6 @@
 angular.module('<%= appname %>').factory('<%= _.camelize(name) %>',function() {
 
-	var <%= _.camelize(name) %> = {};
+    var <%= _.camelize(name) %> = {};
 
-	return <%= _.camelize(name) %>;
+    return <%= _.camelize(name) %>;
 });

--- a/utils.js
+++ b/utils.js
@@ -14,19 +14,19 @@ exports.ROUTE_MARKER = "/* Add New Routes Above */";
 exports.STATE_MARKER = "/* Add New States Above */";
 
 exports.addToFile = function(filename,lineToAdd,beforeMarker){
-	try {
-		var fullPath = path.resolve(process.cwd(),filename);
-		var fileSrc = fs.readFileSync(fullPath,'utf8');
+    try {
+        var fullPath = path.resolve(process.cwd(),filename);
+        var fileSrc = fs.readFileSync(fullPath,'utf8');
 
-		var indexOf = fileSrc.indexOf(beforeMarker);
+        var indexOf = fileSrc.indexOf(beforeMarker);
         var lineStart = fileSrc.substring(0,indexOf).lastIndexOf('\n') + 1;
         var indent = fileSrc.substring(lineStart,indexOf);
-		fileSrc = fileSrc.substring(0,indexOf) + lineToAdd + "\n" + indent + fileSrc.substring(indexOf);
+        fileSrc = fileSrc.substring(0,indexOf) + lineToAdd + "\n" + indent + fileSrc.substring(indexOf);
 
-		fs.writeFileSync(fullPath,fileSrc);
-	} catch(e) {
-		throw e;
-	}
+        fs.writeFileSync(fullPath,fileSrc);
+    } catch(e) {
+        throw e;
+    }
 };
 
 exports.processTemplates = function(name,dir,type,that,defaultDir,configName,module){


### PR DESCRIPTION
Many templates had indentation where some lines were indented with tabs and others with 4 spaces, in the same file. I did a `sed -i` across all .js files containing tabs and replaced them with 4 spaces each. The result is source code which is consistently beautiful across different editors.

Note: There were a few `foo-spec.js` files which appeared to use 2 tabs for indentation on some lines. I left them alone since they weren't tabs, but they remain inconsistent with the 4-space indents everywhere else in the project.
