### PR TITLE
Fixes cgross/generator-cg-angular#92

### DIFF
--- a/CUSTOMIZING.md
+++ b/CUSTOMIZING.md
@@ -41,6 +41,7 @@ Here is an example configuration that matches the default behavior of the subgen
 ```js
 {
 	"uirouter": false,
+	"jsstrict": false,
 	"partialDirectory": "partial/",
 	"directiveDirectory": "directive/",
 	"serviceDirectory": "service/",

--- a/app/index.js
+++ b/app/index.js
@@ -51,6 +51,22 @@ CgangularGenerator.prototype.askFor = function askFor() {
     }.bind(this));
 };
 
+CgangularGenerator.prototype.askForStrict = function askFor() {
+    var cb = this.async();
+
+    var prompts = [{
+        type: 'confirm',
+        name: 'jsstrict',
+        message: 'Would you like your AngularJS code to \'use strict\'?',
+        default: true
+    }];
+
+    this.prompt(prompts, function (props) {
+        this.config.set('jsstrict', !!props.jsstrict);
+        cb();
+    }.bind(this));
+};
+
 CgangularGenerator.prototype.askForUiRouter = function askFor() {
     var cb = this.async();
 

--- a/app/templates/skeleton/app.js
+++ b/app/templates/skeleton/app.js
@@ -1,21 +1,21 @@
 angular.module('<%= _.camelize(appname) %>', ['ui.bootstrap','ui.utils','<%= routerModuleName %>','ngAnimate']);
 <% if (!uirouter) { %>
 angular.module('<%= _.camelize(appname) %>').config(function($routeProvider) {
-
+    <%= config.get('jsstrict') ? "'use strict';\n" : "" %>
     /* Add New Routes Above */
     $routeProvider.otherwise({redirectTo:'/home'});
 
 });
 <% } %><% if (uirouter) { %>
 angular.module('<%= _.camelize(appname) %>').config(function($stateProvider, $urlRouterProvider) {
-
+    <%= config.get('jsstrict') ? "'use strict';\n" : "" %>
     /* Add New States Above */
     $urlRouterProvider.otherwise('/home');
 
 });
 <% } %>
 angular.module('<%= _.camelize(appname) %>').run(function($rootScope) {
-
+    <%= config.get('jsstrict') ? "'use strict';\n" : "" %>
     $rootScope.safeApply = function(fn) {
         var phase = $rootScope.$$phase;
         if (phase === '$apply' || phase === '$digest') {

--- a/directive/templates/complex/directive.js
+++ b/directive/templates/complex/directive.js
@@ -1,4 +1,5 @@
 angular.module('<%= appname %>').directive('<%= _.camelize(name) %>', function() {
+    <%= config.get('jsstrict') ? "'use strict';\n" : "" %>
     return {
         restrict: 'E',
         replace: true,

--- a/directive/templates/simple/directive.js
+++ b/directive/templates/simple/directive.js
@@ -1,4 +1,5 @@
 angular.module('<%= appname %>').directive('<%= _.camelize(name) %>', function() {
+    <%= config.get('jsstrict') ? "'use strict';\n" : "" %>
     return {
         restrict: 'A',
         link: function(scope, element, attrs, fn) {

--- a/filter/templates/filter.js
+++ b/filter/templates/filter.js
@@ -1,4 +1,5 @@
 angular.module('<%= appname %>').filter('<%= _.camelize(name) %>', function() {
+    <%= config.get('jsstrict') ? "'use strict';\n" : "" %>
     return function(input,arg) {
         return 'output';
     };

--- a/modal/templates/modal.js
+++ b/modal/templates/modal.js
@@ -1,4 +1,4 @@
 angular.module('<%= appname %>').controller('<%= ctrlname %>',function($scope){
-
+    <%= config.get('jsstrict') ? "'use strict';\n" : "" %>
 
 });

--- a/module/templates/module.js
+++ b/module/templates/module.js
@@ -1,13 +1,13 @@
 angular.module('<%= _.camelize(name) %>', ['ui.bootstrap','ui.utils','<%= routerModuleName %>','ngAnimate']);
 <% if (!uirouter) { %>
 angular.module('<%= _.camelize(name) %>').config(function($routeProvider) {
-
+    <%= config.get('jsstrict') ? "'use strict';\n" : "" %>
     /* Add New Routes Above */
 
 });
 <% } %><% if (uirouter) { %>
 angular.module('<%= _.camelize(name) %>').config(function($stateProvider) {
-
+    <%= config.get('jsstrict') ? "'use strict';\n" : "" %>
     /* Add New States Above */
 
 });

--- a/partial/templates/partial.js
+++ b/partial/templates/partial.js
@@ -1,4 +1,4 @@
 angular.module('<%= appname %>').controller('<%= ctrlname %>',function($scope){
-
+    <%= config.get('jsstrict') ? "'use strict';\n" : "" %>
 
 });

--- a/service/templates/service.js
+++ b/service/templates/service.js
@@ -1,5 +1,5 @@
 angular.module('<%= appname %>').factory('<%= _.camelize(name) %>',function() {
-
+    <%= config.get('jsstrict') ? "'use strict';\n" : "" %>
     var <%= _.camelize(name) %> = {};
 
     return <%= _.camelize(name) %>;


### PR DESCRIPTION
Allows the generation of files with a ‘use strict’. This option is configurable with the boolean property, ‘jsstrict’ in yo-rc.json.

During the initial setup, the user is prompted whether or not to "use strict".