### PR TITLE
fixed grunt serve error by updating version of grunt-contrib-jshint

### DIFF
--- a/app/templates/skeleton/package.json
+++ b/app/templates/skeleton/package.json
@@ -12,7 +12,7 @@
     "grunt-contrib-concat": "~0.3",
     "grunt-contrib-cssmin": "~0.7",
     "grunt-contrib-uglify": "~0.2",
-    "grunt-contrib-jshint": "~0.9",
+    "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-htmlmin": "~0.1",
     "grunt-contrib-imagemin": "~0.4",
     "grunt-contrib-less": "~0.8",


### PR DESCRIPTION
Warning: Path must be a string. Received null Use --force to continue.